### PR TITLE
Refined Login Navbar Design

### DIFF
--- a/client/src/components/Navbar2/Navbar2.css
+++ b/client/src/components/Navbar2/Navbar2.css
@@ -10,15 +10,15 @@
 }
 /* Text In the Navbar Styling */
 .nav a {
-  color: white !important;
   margin-left: 24px;
   border-bottom: 3px solid transparent;
-  font-weight: bold;
+  margin: auto;
 }
 /* Underline the Current Page */
 .nav a.active {
   text-decoration: none;
   border-bottom: 3px solid #F93C3C !important;
+  font-weight: bold;
 }
 /* Underline the Hovered Pages */
 .nav a:hover{


### PR DESCRIPTION
Made it so that the current tab is the one white/bolded out, and the red underline for selected tab in the hamburger menu is the same size as the text of that tab.

Before:
![Screen Shot 2020-10-01 at 2 47 23 PM](https://user-images.githubusercontent.com/29936211/94851874-088a0300-03f7-11eb-97ec-1c3be762ccf7.png)
![Screen Shot 2020-10-01 at 2 47 39 PM](https://user-images.githubusercontent.com/29936211/94851876-088a0300-03f7-11eb-8660-65c4db97f1e0.png)

After:
![Screen Shot 2020-10-01 at 2 46 28 PM](https://user-images.githubusercontent.com/29936211/94851901-13449800-03f7-11eb-98c1-5030e7d20cd0.png)
![Screen Shot 2020-10-01 at 2 46 59 PM](https://user-images.githubusercontent.com/29936211/94851902-13dd2e80-03f7-11eb-821b-87a70d6db614.png)